### PR TITLE
Add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch: # Enable manual triggering
 
 jobs:
   build:


### PR DESCRIPTION
Add manual trigger capability to build workflow.

Changes:
- Add workflow_dispatch event trigger to enable manual workflow runs
- Maintain existing push and pull_request triggers

Link to Devin run: https://app.devin.ai/sessions/5b1e7ac36f074310aa300577143a9b62