### PR TITLE
Add Docker build and push to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js (Shared)
@@ -56,3 +62,20 @@ jobs:
       - name: Build Server
         working-directory: apps/server
         run: npm run build
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        run: |
+          # Build and push client image
+          docker build -t ghcr.io/${{ github.repository }}/client:latest ./apps/client
+          docker push ghcr.io/${{ github.repository }}/client:latest
+          
+          # Build and push server image
+          docker build -t ghcr.io/${{ github.repository }}/server:latest ./apps/server
+          docker push ghcr.io/${{ github.repository }}/server:latest


### PR DESCRIPTION
Add Docker image building and pushing to GitHub Container Registry.

Changes:
- Add GitHub Container Registry authentication
- Configure Docker build and push steps
- Set required permissions for package publishing

Link to Devin run: https://app.devin.ai/sessions/5b1e7ac36f074310aa300577143a9b62